### PR TITLE
Full Ruby client (exchange_code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in civic_sip.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,49 @@
+PATH
+  remote: .
+  specs:
+    civic_sip (1.0.0)
+      jwt (>= 2.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.3)
+    hashdiff (0.3.7)
+    jwt (2.1.0)
+    public_suffix (3.0.2)
+    rake (10.5.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    safe_yaml (1.0.4)
+    webmock (3.4.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.16)
+  civic_sip!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  webmock (~> 3.4.1)
+
+BUNDLED WITH
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WORK IN PROGRESS
 
-**Contributors**: Before submitting a pull request, be sure to read and agree to our [Terms and Conditions](https://s3-us-west-2.amazonaws.com/civic.com/cdp_terms.pdf). 
+**Contributors**: Before submitting a pull request, be sure to read and agree to our [Terms and Conditions](https://s3-us-west-2.amazonaws.com/civic.com/cdp_terms.pdf).
 
 # Civic SIP Plugin - Ruby
 
@@ -12,30 +12,80 @@ Civic [Secure Identity Platform (SIP)](https://www.civic.com/products/secure-ide
 
 ### Dependencies
 
-* {{ DEPENDENCY_LIST_ITEM }}
+* The wonderful JWT gem
 
 ### Installing
 
-{{ HOWTO_INSTALL }}
+## Using Rubygems:
 
 ```
-{{ INSTALL_EXAMPLE }}
+gem install civic_sip
 ```
 
-### Usage
+## Using Bundler:
 
-{{ HOWTO_USE }}
+Add the following to your Gemfile:
 
 ```
-{{ USE_EXAMPLE }}
+gem 'civic_sip'
 ```
+
+And run `bundle_install`
+
+### Global Configuration
+
+CivicSIP can be configured globally.
+
+```ruby
+CivicSIP.configure do |config|
+  config.private_signing_key = 'your private signing key'
+  config.secret              = 'your secret'
+  config.app_id              = 'your app ID'
+end
+```
+
+### Usage (with global configuration)
+
+```ruby
+CivicSIP.exchange_code('token received from civic.sip.js')
+
+# A successful request returns a hash like this:
+#
+# {
+#   userId: 'user-id',
+#   data: [
+#     {
+#       'label'   => 'contact.personal.email',
+#       'value'   => 'foo@example.com',
+#       'isValid' => true,
+#       'isOwner' => true
+#     },
+#     ...
+#   ]
+# }
+```
+
+### Usage (without global configuration)
+
+If you don't want to configure CivicSIP globally,
+you can pass your app ID, signing key, and secret directly
+to the client and exchange your code that way:
+
+```ruby
+CivicSIP::Client.new(
+  'your app ID',
+  'your private signing key',
+  'your secret'
+).exchange_code('token received from civic.sip.js')
+```
+
 ### Running tests
 
-{{ HOWTO_RUN_TEST }}
+The tests are written with rspec and the suite can be run with:
 
-## Deployment
-
-{{ HOW_TO_DEPLOY }}
+```
+rake spec
+```
 
 ## Contributing
 
@@ -45,7 +95,8 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/civic-community/civic-sip-api-ruby/tags).
 ## Authors
 
-* **Author 1**
+* **Jim Ryan**
+
 See also the list of [contributors](https://github.com/civic-community/civic-sip-api-ruby/contributors) who participated in this project.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -183,9 +183,17 @@ For subsequent logins the `userId` returned by `exchange_code` can be used to as
 
 ## Running tests
 
-The tests are written with rspec and the suite can be run with:
+The tests are written with rspec.
 
+You can install the development dependencies by running:
+
+```sh
+bin/setup
 ```
+
+You can then run the suite with:
+
+```sh
 rake spec
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,38 @@ Civic [Secure Identity Platform (SIP)](https://www.civic.com/products/secure-ide
 
 **Welcome Bounty Hunters!** Part of your job will be filling out the below. We've included some place holder notes to help with the structure. See [requirements](REQUIREMENTS.md) and [contributing](CONTRIBUTING.md) to get started.
 
-## Geting Started
+## What is Civic
+Civic is the next generation blockchain based secure identity management platform.
+It allows to authenticate users without the need for traditional physical IDs,
+knowledge based authentication, username/password, and two-factor hardware tokens.
+Civic's Secure Identity Platform (SIP) uses a verified identity for multi-factor authentication
+on web and mobile apps without the need for usernames or passwords.
+The SIP provides partners with functionality such as:
+* secure public or private 2FA user login,
+* onboarding of verified users with customized flows.
 
-### Dependencies
+## How Civic works
+An individual downloads the Civic App and completes an Identity Validation Process customized to the Civic Business Customer requirements.
+This process verifies Personally Identifiable Information (PII) to ensure ownership of the identity with enough data to establish the level of trust required by the Civic Business Customer.
+In other words, more PII may be collected to establish a high level of trust,
+e.g. scanning of passport, driver’s license and social security number, while only minimal PII, e.g. only email and mobile phone number, may be collected for new users when the Civic Business Customer only wants to verify the user is real and unique.
 
-* The wonderful JWT gem
+After validation, the user is now considered a Civic Member with authenticated **identity data secured in the Civic App on the user’s device, not stored by Civic.**
+The Civic Member may share this previously authenticated identity data with Civic Business Customers, businesses that enter into a partnership with Civic which leverage blockchain technology for real-time authentication of Civic Member identity data.
 
-### Installing
+**Ultimately Civic Members have full control over their identity data and ability to choose what and who to share with.**
 
-## Using Rubygems:
+## Getting Started
+In order to integrate your application with Civic you need to do the following:
 
-```
-gem install civic_sip
-```
+#### 1. **Obtain application credentials (keys)**
+Go to [Civic Partner Portal](https://sip-partners.civic.com). If you already registered as Civic partner you may proceed with application registration (option B) otherwise you will be asked for some company details to complete the partner registration process.
+  * (A) To become a partner you will need to provide Company Name, Primary Domain, Primary Contact and accept Developer Terms of Service.
+  **Important: To prove that you are eligible to create an account for a company, Civic requires you to use your company email address when signing up to Civic and enforces that your email domain matches the primary domain of your company during registration.**
 
-## Using Bundler:
+  * (B) Click "New Application" button and fill in the Application Form (Application Name, Whitelisted Domains, Full URL to logo image file). After submitting the form you will be provided with application credentials: `App ID, Signing keypair, App Secret, Encryption keypair`. This credentials will be used later on to configure Civic SIP client.
+
+#### 2. Install the civic_sip gem
 
 Add the following to your Gemfile:
 
@@ -30,21 +47,75 @@ Add the following to your Gemfile:
 gem 'civic_sip'
 ```
 
-And run `bundle_install`
+And run `bundle install`
 
-### Global Configuration
+#### 3. Implement User-Agent (Browser) functionality
+Include the `civic.sip.js` script on your page. This exposes a single global object, civic.
+```html
+<link rel="stylesheet" href="https://hosted-sip.civic.com/css/civic-modal.css">
 
-CivicSIP can be configured globally.
+<script src="https://hosted-sip.civic.com/js/civic.sip.min.js"></script>
+```
+Instantiate instance of `civic.sip`.
+```javascript
+var civicSip = new civic.sip({ appId: 'Your Application ID' });
+```
+Implement event handlers.
+```javascript
+// Start scope request
+$('button.js-signup').click(function(event) {
+    civicSip.signup({ style: 'popup', scopeRequest: civicSip.ScopeRequests.BASIC_SIGNUP });
+});
+
+// Listen for data
+civicSip.on('auth-code-received', function (event) {
+    /*
+        event:
+        {
+            event: "scoperequest:auth-code-received",
+            response: "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJqdGkiOiI2Y2EwNTEzMi0wYTJmLTQwZjItYTg2Yi03NTkwYmRjYzBmZmUiLCJpYXQiOjE0OTQyMjUxMTkuMTk4LCJleHAiOjE0OTQyMjUyOTkuMTk4LCJpc3MiOiJjaXZpYy1zaXAtaG9zdGVkLXNlcnZpY2UiLCJhdWQiOiJodHRwczovL3BoNHg1ODA4MTUuZXhlY3V0ZS1hcGkudXMtZWFzdC0xLmFtYXpvbmF3cy5jb20vZGV2Iiwic3ViIjoiY2l2aWMtc2lwLWhvc3RlZC1zZXJ2aWNlIiwiZGF0YSI6eyJjb2RlVG9rZW4iOiJjY2E3NTE1Ni0wNTY2LTRhNjUtYWZkMi1iOTQzNjc1NDY5NGIifX0.gUGzPPI2Av43t1kVg35diCm4VF9RUCF5d4hfQhcSLFvKC69RamVDYHxPvofyyoTlwZZaX5QI7ATiEMcJOjXRYQ",
+            type: "code"
+        }
+    */
+
+    // Encoded JWT Token is sent to the server
+    const jwtToken = event.response;
+
+    // Your function to pass JWT token to your server
+    sendAuthCode(jwtToken);
+});
+
+civicSip.on('user-cancelled', function (event) {
+    /*
+        event:
+        {
+          event: "scoperequest:user-cancelled"
+        }
+    */
+});
+
+// Error events
+civicSip.on('civic-sip-error', function (error) {
+    // handle error display if necessary.
+    console.log('Error type = ' + error.type);
+    console.log('Error message = ' + error.message);
+});
+```
+
+#### 4. Implement Application server functionality
+Use `CivicSIP` with your application credentials to exchange the authorization code retrieved with civic.sip.js for the requested user data.
+
+`CivicSIP` can (optionally) be configured globally:
 
 ```ruby
 CivicSIP.configure do |config|
-  config.private_signing_key = 'your private signing key'
-  config.secret              = 'your secret'
-  config.app_id              = 'your app ID'
+  config.private_signing_key = 'Your Private Signing Key'
+  config.secret              = 'Your Secret'
+  config.app_id              = 'Your Application ID'
 end
 ```
 
-### Usage (with global configuration)
+Then used to exchange codes:
 
 ```ruby
 CivicSIP.exchange_code('token received from civic.sip.js')
@@ -65,11 +136,7 @@ CivicSIP.exchange_code('token received from civic.sip.js')
 # }
 ```
 
-### Usage (without global configuration)
-
-If you don't want to configure CivicSIP globally,
-you can pass your app ID, signing key, and secret directly
-to the client and exchange your code that way:
+If you don't want to configure `CivicSIP` globally, you can pass your app ID, signing key, and secret directly to the client and exchange your code that way:
 
 ```ruby
 CivicSIP::Client.new(
@@ -79,7 +146,42 @@ CivicSIP::Client.new(
 ).exchange_code('token received from civic.sip.js')
 ```
 
-### Running tests
+If `CivicSIP` can't verify the signature on the JWT returned by the API, it will raise a `JWT::VerificationError`.
+
+If the API responds in error, it will raise a `CivicSIP::APIError`.
+
+## Civic integration
+Currently only Civic Hosted option is available for partners integration. This is the simplest route to integration as it provides a flow similar to the traditional oAuth2 authorization code flow, with Civic performing the role of the Authorization server.
+This option delivers a secure solution and minimises server side development required by the partner.
+
+The following user signup example explains the general Civic Hosted option codeflow.
+![Civic Code Flow](http://docs.civic.com/images/codeflow.png)
+
+1. **Signup.** The user clicks "Signup with Civic" button on your website page. The event handler calls a method in the Civic JS library to initiate signup.
+
+2. **Launch Popup.** A modal is displayed which contains an iframe to house the QR code. A request is made to the Civic server to generate a QR code for your scope request.
+
+3. **QR Code.** The server checks that the domain for the parent document of the iframe corresponds to the domain white list set in the partner account before serving the code. The QR code bridges the air gap between the browser and the user’s smart phone.
+
+4. **Scan.** The user scans the QR code using the Civic mobile app and is prompted to authorize or deny the scope request. The prompt highlights the data that is being requested and the requesting party.
+
+5. **Grant Request.** Upon granting the request, the data is sent to the Civic server.
+
+6. **Verify offline.** The Civic SIP server verifies the authenticity and integrity of the attestations received from the user’s mobile app. This process proves that the user data was attested to by Civic and that the user is currently in control of the private keys relevant to the data.
+
+7. **Verify on the blockchain.** The Civic server then verifies that the attestations are still valid on the blockchain and have not been revoked.
+
+8. **Encrypt and cache.** The data is encrypted and cached on the Civic server. Once this data is cached, a polling request from the iframe will receive a response containing an authorization code wrapped in a JWT token. The CivicJS browser-side library passes the token to the parent document. Your site is then responsible for passing the JWT token to your server.
+
+9. **Authorization Code exchange.** Use the Civic SIP client (this library) on your server to communicate with the Civic SIP server and exchange the authorization code (AC) for the requested user data. The SIP server first validates the JWT token, ensuring it was issued by Civic, is being used by the correct application id, and that the expiry time on the token has not lapsed. The enclosed AC is then verified and the encrypted cached data returned.
+
+10. **Decrypt.** Your server receives the encrypted data where it is decrypted using your application secret key. The result will contain a userId and any data requested (such as email, mobile number etc).
+
+11. **Complete user signup.** At this point you can store the necessary data and redirect the user to your app’s logged in experience.
+
+For subsequent logins the `userId` returned by `exchange_code` can be used to associate the user with your accounts system.
+
+## Running tests
 
 The tests are written with rspec and the suite can be run with:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "civic_sip"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/civic_sip.gemspec
+++ b/civic_sip.gemspec
@@ -1,0 +1,27 @@
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "civic_sip/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "civic_sip"
+  spec.version       = CivicSIP::VERSION
+  spec.authors       = ["Jim Ryan"]
+  spec.email         = ["jim@room118solutions.com"]
+
+  spec.summary       = %q{Interfaces with Civic's SIP service to exchange an authorization code for user data}
+  spec.homepage      = "https://github.com/civic-community/civic-sip-api-ruby"
+
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency "jwt", ">= 2.1"
+
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 3.4.1"
+end

--- a/lib/civic_sip.rb
+++ b/lib/civic_sip.rb
@@ -1,0 +1,22 @@
+require 'civic_sip/version'
+require 'civic_sip/configuration'
+require 'civic_sip/api_error'
+require 'civic_sip/client'
+
+module CivicSIP
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration
+  end
+
+  def self.exchange_code(token)
+    Client.new(
+      configuration.app_id,
+      configuration.private_signing_key,
+      configuration.secret
+    ).exchange_code token
+  end
+end

--- a/lib/civic_sip/api_error.rb
+++ b/lib/civic_sip/api_error.rb
@@ -1,0 +1,11 @@
+module CivicSIP
+  class APIError < StandardError
+    attr_reader :http_code
+
+    def initialize(http_code, message)
+      super message
+
+      @http_code = http_code
+    end
+  end
+end

--- a/lib/civic_sip/client.rb
+++ b/lib/civic_sip/client.rb
@@ -1,0 +1,155 @@
+require 'securerandom'
+require 'net/http'
+require 'jwt'
+
+module CivicSIP
+  class Client
+    PUBLIC_KEY_HEX = '049a45998638cfb3c4b211d72030d9ae8329a242db63bfb0076a54e7647370a8ac5708b57af6065805d5a6be72332620932dbb35e8d318fce18e7c980a0eb26aa1'
+    BASE_URL       = 'https://api.civic.com/sip'
+    PATH           = 'scopeRequest/authCode'
+
+    def initialize(app_id, private_signing_key, secret)
+      @app_id              = app_id
+      @private_signing_key = private_signing_key
+      @secret              = secret
+    end
+
+    # Takes JWT retrieved from the Javascript SDK
+    # and exchanges it for the user's ID and data
+    #
+    # The request header includes an Authorization header,
+    # which looks like this: Civic <request jwt>.<message_digest>
+    #
+    # The <request jwt> is a JWT signed with the app's private signing key
+    # that expires in 3 minutes and has a payload describing the API
+    # endpoint being requested (POST to scopeRequest/authCode)
+    #
+    # The <message digest> is a base64 encoded HMAC SHA256 digest
+    # of the request body created using the app's secret.
+    #
+    # A successful response from SIP is a JSON string that looks like this:
+    # {
+    #   data: <JWT>,
+    #   userId: <user id>,
+    #   encrypted: true
+    #   alg: 'aes'
+    # }
+    #
+    # <user id> is the requested user's ID
+    #
+    # <JWT> is a JWT signed using SIP's private key,
+    # which we can verify using its public key, stored in PUBLIC_KEY_HEX.
+    # The JWT's payload is the user's data, encrypted using AES and the app's secret.
+    #
+    # If we fail to verify the signature on the returned JWT,
+    # we'll raise a JWT::VerificationError
+    #
+    # If the API responds with a non-200 status,
+    # we'll raise a CivicSIP::APIError with the HTTP status code and response body.
+    def exchange_code(token)
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request build_request(token)
+      end
+
+      if response.kind_of?(Net::HTTPSuccess)
+        json = JSON.parse(response.body)
+
+        {
+          userId: json['userId'],
+          data: JSON.parse(decrypted_token_data(json['data']))
+        }
+      else
+        raise APIError.new(response.code, response.body)
+      end
+    end
+
+    private
+
+      def uri
+        @uri ||= URI("#{BASE_URL}/prod/#{PATH}")
+      end
+
+      def ecdsa_signing_key
+        OpenSSL::PKey::EC.new('prime256v1').tap do |ecdsa_key|
+          ecdsa_key.private_key = OpenSSL::BN.new(@private_signing_key, 16)
+        end
+      end
+
+      def request_token
+        JWT.encode(
+          {
+            iat: Time.now.to_i,            # Issued at (now)
+            exp: (Time.now + 60 * 3).to_i, # Expires at (3 minutes from now)
+            iss: @app_id,                  # Issuer
+            aud: BASE_URL,                 # Audience
+            sub: @app_id,                  # Subject
+            jti: SecureRandom.hex,         # ID
+            data: [                        # Custom claim
+              method: 'POST',
+              path:   PATH
+            ]
+          },
+          ecdsa_signing_key,
+          'ES256'
+        )
+      end
+
+      def digest_for(str)
+        Base64.encode64(
+          OpenSSL::HMAC.digest(
+            OpenSSL::Digest.new('sha256'),
+            @secret,
+            str
+          )
+        )
+      end
+
+      def build_request(auth_token)
+        body = {
+          authToken: auth_token
+        }.to_json
+
+        headers = {
+          'Accept'        => 'application/json',
+          'Content-Type'  => 'application/json',
+          'Authorization' => "Civic #{request_token}.#{digest_for(body)}"
+        }
+
+        Net::HTTP::Post.new(uri.request_uri, headers).tap do |request|
+          request.body = body
+        end
+      end
+
+      # Decrypts an encrypted SIP response using the app's secret.
+      #
+      # The first 32 characters are the hex representation of
+      # the encrypted data's initialization vector.
+      # The remaining characters are the encrypted data, base64 encoded.
+      def decrypt(data)
+        cipher = OpenSSL::Cipher::AES.new(128, :CBC)
+        cipher.decrypt
+
+        cipher.key = [@secret].pack('H*')
+        cipher.iv  = [data[0..31]].pack('H*')
+
+        cipher.update(Base64.decode64(data[32..-1])) + cipher.final
+      end
+
+      def sip_public_key
+        OpenSSL::PKey::EC.new('prime256v1').tap do |ecdsa_key|
+          ecdsa_key.public_key = OpenSSL::PKey::EC::Point.new(
+            ecdsa_key.group,
+            OpenSSL::BN.new(PUBLIC_KEY_HEX, 16)
+          )
+        end
+      end
+
+      # Accepts a response JWT, decodes it,
+      # verifies its signature, and decrypts its payload.
+      def decrypted_token_data(token)
+        decoded_token = JWT.decode(token, sip_public_key, true, { 'algorithm': 'ES256' })
+
+        decrypt decoded_token[0]['data']
+      end
+  end
+end

--- a/lib/civic_sip/configuration.rb
+++ b/lib/civic_sip/configuration.rb
@@ -1,0 +1,5 @@
+module CivicSIP
+  class Configuration
+    attr_accessor :private_signing_key, :secret, :app_id
+  end
+end

--- a/lib/civic_sip/version.rb
+++ b/lib/civic_sip/version.rb
@@ -1,0 +1,3 @@
+module CivicSIP
+  VERSION = "1.0.0"
+end

--- a/spec/civic_sip/client_spec.rb
+++ b/spec/civic_sip/client_spec.rb
@@ -1,0 +1,169 @@
+RSpec.describe CivicSIP::Client do
+  include SIPRequestHelpers
+
+  describe '#exchange_code' do
+    let(:signing_key_hex) { 'ec844af6422e1f3db7bdbf6443bd47ea9e58f31a708045a9b8c4f36a3987bad4' }
+    let(:secret) { '50c0c3273d5a7ca8a04287f82c6d0111' }
+
+    # Generate our own SIP key pair (so that we can sign and verify mocked SIP responses)
+    let(:sip_key) do
+      OpenSSL::PKey::EC.new('prime256v1').tap do |ecdsa_key|
+        ecdsa_key.generate_key
+      end
+    end
+
+    let(:user_data) do
+      [
+        {
+          'label'   => 'contact.personal.email',
+          'value'   => 'foo@example.com',
+          'isValid' => true,
+          'isOwner' => true
+        },
+
+        {
+          'label'   => 'contact.personal.phoneNumber',
+          'value'   => '+1 1235551234',
+          'isValid' => true,
+          'isOwner' => true
+        }
+      ]
+    end
+
+    before do
+      # We normally use a hardcoded public key to verify signed SIP JWTs,
+      # but we stub it out with the public key that's part of a key pair
+      # that we generated, so that we can sign/verify mocked responses
+      stub_const 'CivicSIP::Client::PUBLIC_KEY_HEX', sip_key.public_key.to_bn.to_s(16).downcase
+    end
+
+    subject { described_class.new 'app42', signing_key_hex, secret }
+
+    context 'successful exchange' do
+      let(:digest) do
+        encoded_message_digest secret, { authToken: 'token42' }.to_json
+      end
+
+      # Create a JWT response token, signed with faked SIP key,
+      # with encrypted user data payload (encrypted with app's secret)
+      let!(:response_token) do
+        sip_response_token encrypt(secret, user_data.to_json), sip_key
+      end
+
+      before do
+        # Stub Time and SecureRandom to guarantee that our request token always looks the same
+
+        # iat/exp depend on current time
+        allow(Time).to receive(:now).and_return(Time.new(2018, 5, 4, 12))
+
+        # JWT ID uses SecureRandom
+        allow(SecureRandom).to receive(:hex) { '8634cbe609a2ffe273344573bf243a80' }
+      end
+
+      it 'makes request with proper Authorization header and decrypts and returns response' do
+        # We have to stub the request JWT, because the signature includes a random component
+        # This was created using the expected values, which are asserted below
+        request_token = "eyJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE1MjU0NDk2MDAsImV4cCI6MTUyNTQ0OTc4MCwiaXNzIjoiYXBwNDIiLCJhdWQiOiJodHRwczovL2FwaS5jaXZpYy5jb20vc2lwIiwic3ViIjoiYXBwNDIiLCJqdGkiOiI4NjM0Y2JlNjA5YTJmZmUyNzMzNDQ1NzNiZjI0M2E4MCIsImRhdGEiOlt7Im1ldGhvZCI6IlBPU1QiLCJwYXRoIjoic2NvcGVSZXF1ZXN0L2F1dGhDb2RlIn1dfQ._YlX9ENaUwRkwNLcffAUw8h3TJdWceVZZnbnogfbn_qS6kEs01-XTUBKMRSfJ9rJNV_7bzjsvtXvsewGzLcaGQ"
+
+        expect(JWT).to receive(:encode) do |payload, key, algorithm|
+          expect(payload).to eq(
+            iat: Time.new(2018, 5, 4, 12).to_i,
+            exp: (Time.new(2018, 5, 4, 12) + 60 * 3).to_i,
+            iss: 'app42',
+            aud: 'https://api.civic.com/sip',
+            sub: 'app42',
+            jti: '8634cbe609a2ffe273344573bf243a80',
+            data: [
+              method:  'POST',
+              path:    'scopeRequest/authCode'
+            ]
+          )
+
+          expect(key.private_key.to_s(16).downcase).to eq signing_key_hex
+
+          expect(algorithm).to eq 'ES256'
+
+          request_token
+        end
+
+        # Stub SIP request with expected headers,
+        # and respond with a JWT with encrypted user data as its payload
+        stub_request(
+          :post,
+          "https://api.civic.com/sip/prod/scopeRequest/authCode"
+        ).with(
+          headers: {
+            'Accept'        => 'application/json',
+            'Content-Type'  => 'application/json',
+            'Authorization' => "Civic #{request_token}.#{digest}"
+          },
+          body: {
+            authToken: 'token42'
+          }.to_json
+        ).to_return(
+          status: 200,
+          body: {
+            data: response_token,
+            userId: 'user-123',
+            encrypted: true,
+            alg: 'aes'
+          }.to_json
+        )
+
+        expect(subject.exchange_code('token42')).to eq(
+          userId: 'user-123',
+          data: user_data
+        )
+      end
+    end
+
+    context 'unknown key used to sign response token' do
+      let(:unknown_key) do
+        OpenSSL::PKey::EC.new('prime256v1').tap do |ecdsa_key|
+          ecdsa_key.generate_key
+        end
+      end
+
+      # Sign response with a different/unknown key
+      # (not the private key matching the stubbed SIP public key)
+      let(:response_token) do
+        sip_response_token encrypt(secret, user_data.to_json), unknown_key
+      end
+
+      it 'raises a JWT::VerificationError' do
+        stub_request(
+          :post,
+          "https://api.civic.com/sip/prod/scopeRequest/authCode"
+        ).to_return(
+          status: 200,
+          body: {
+            data: response_token,
+            userId: 'user-123',
+            encrypted: true,
+            alg: 'aes'
+          }.to_json
+        )
+
+        expect { subject.exchange_code('token42') }.to raise_error(JWT::VerificationError)
+      end
+    end
+
+    context 'non-200 API response' do
+      it 'raises a CivicSIP::APIError with the response code and body' do
+        stub_request(
+          :post,
+          "https://api.civic.com/sip/prod/scopeRequest/authCode"
+        ).to_return(
+          status: 400,
+          body: '[Bad Request]: token failed verification'
+        )
+
+        expect { subject.exchange_code('token42') }.to raise_error do |error|
+          expect(error).to be_a CivicSIP::APIError
+          expect(error.http_code).to eq '400'
+          expect(error.message).to eq '[Bad Request]: token failed verification'
+        end
+      end
+    end
+  end
+end

--- a/spec/civic_sip/client_spec.rb
+++ b/spec/civic_sip/client_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe CivicSIP::Client do
       # Create a JWT response token, signed with faked SIP key,
       # with encrypted user data payload (encrypted with app's secret)
       let!(:response_token) do
-        sip_response_token encrypt(secret, user_data.to_json), sip_key
+        sip_response_token encrypt(secret, user_data.to_json), sip_key, 'app42'
       end
 
       before do
@@ -127,7 +127,7 @@ RSpec.describe CivicSIP::Client do
       # Sign response with a different/unknown key
       # (not the private key matching the stubbed SIP public key)
       let(:response_token) do
-        sip_response_token encrypt(secret, user_data.to_json), unknown_key
+        sip_response_token encrypt(secret, user_data.to_json), unknown_key, 'app42'
       end
 
       it 'raises a JWT::VerificationError' do

--- a/spec/civic_sip_spec.rb
+++ b/spec/civic_sip_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe CivicSIP do
+  describe 'configuration' do
+    it 'yields configuration object to block and stores configuration' do
+      CivicSIP.configure do |config|
+        config.private_signing_key = 'private'
+        config.secret              = 'secret'
+        config.app_id              = '4242'
+      end
+
+      expect(CivicSIP.configuration.private_signing_key).to eq 'private'
+      expect(CivicSIP.configuration.secret).to eq 'secret'
+      expect(CivicSIP.configuration.app_id).to eq '4242'
+    end
+  end
+
+  describe '#exchange_code' do
+    before do
+      CivicSIP.configure do |config|
+        config.private_signing_key = '1234'
+        config.secret              = '5678'
+        config.app_id              = 'app1'
+      end
+    end
+
+    it 'creates new Client and exchanges given token' do
+      client = double(CivicSIP::Client)
+
+      expect(CivicSIP::Client).to receive(:new).with('app1', '1234', '5678').and_return(client)
+
+      expect(client).to receive(:exchange_code).with('jwttoken').and_return({ userId: '42', data: [] })
+
+      expect(CivicSIP.exchange_code('jwttoken')).to eq({ userId: '42', data: [] })
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,24 @@
+require 'bundler/setup'
+require 'webmock/rspec'
+require 'civic_sip'
+
+Dir["#{File.expand_path(File.dirname(__FILE__))}/support/**/*.rb"].each { |f| require f }
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  # Clean up cached configuration after each spec
+  config.after(:each) do
+    if CivicSIP.instance_variable_defined? :@configuration
+      CivicSIP.remove_instance_variable :@configuration
+    end
+  end
+end

--- a/spec/support/sip_request_helpers.rb
+++ b/spec/support/sip_request_helpers.rb
@@ -1,0 +1,47 @@
+module SIPRequestHelpers
+  # Given a String hex key and some String data,
+  # encrypts with aes-128-cbc and returns
+  # a String with the iv as a hex string
+  # followed by the encrypted data base64 encoded
+  # (this is how SIP returns the encrypted user data)
+  def encrypt(hex_key, data)
+    cipher = OpenSSL::Cipher::AES.new(128, :CBC)
+    cipher.encrypt
+
+    iv = cipher.random_iv
+
+    cipher.key = [hex_key].pack('H*')
+
+    encrypted = cipher.update(data) + cipher.final
+
+    "#{iv.unpack('H*')[0]}#{Base64.encode64(encrypted)}"
+  end
+
+  # Encodes/signs a JWT similar to how SIP does
+  def sip_response_token(data, key)
+    JWT.encode(
+      {
+        jti: SecureRandom.hex,
+        iat: Time.now.to_i,
+        exp: (Time.now + 60 * 30).to_i,
+        iss: 'civic-sip-hosted-service',
+        aud: 'https://api.civic.com/sip/',
+        sub: 'app42',
+        data: data
+      },
+      key,
+      'ES256'
+    )
+  end
+
+  # Base64 encoded HMAC sha256 message digest of the given body using given key
+  def encoded_message_digest(key, body)
+    Base64.encode64(
+      OpenSSL::HMAC.digest(
+        OpenSSL::Digest.new('sha256'),
+        key,
+        body
+      )
+    ).strip
+  end
+end

--- a/spec/support/sip_request_helpers.rb
+++ b/spec/support/sip_request_helpers.rb
@@ -18,7 +18,7 @@ module SIPRequestHelpers
   end
 
   # Encodes/signs a JWT similar to how SIP does
-  def sip_response_token(data, key)
+  def sip_response_token(data, key, app_id)
     JWT.encode(
       {
         jti: SecureRandom.hex,
@@ -26,7 +26,7 @@ module SIPRequestHelpers
         exp: (Time.now + 60 * 30).to_i,
         iss: 'civic-sip-hosted-service',
         aud: 'https://api.civic.com/sip/',
-        sub: 'app42',
+        sub: app_id,
         data: data
       },
       key,


### PR DESCRIPTION
Hey all,

I've written the full Ruby library, with tests and wrote documentation.  I copied a lot of the README from the PHP project (hope that's alright) - I thought it made sense that the various clients have similar documentation, adapted for the specific language.

I have _not_ released the gem yet - I wasn't sure if you wanted me to do that.  I am happy to release it if you'd like, and add whoever you'd like as a maintainer.  `civic_sip` is available, so that's what I named the library and used in the README.

The only thing missing from the REQUIREMENTS is the PoC page.  What do you think would be the best way to demo this? 

Please let me know if there are any changes or improvements you'd like.

This will be used in a production application in a few weeks, and I will continue improving it if any issues arise.

Here is my ETH address for the bounty: 0xeC9F7845ab14d3766c9Fc77Df4BC01429F251B0a

Thanks for Civic - it's been a great developer and user experience! 